### PR TITLE
Подключение front-components к OTP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9003,8 +9003,8 @@
       }
     },
     "front-shared": {
-      "version": "git+https://github.com/timepad/front-shared.git#f9e7363ba4dc26050fdeb01f2d25315e39c21bcb",
-      "from": "git+https://github.com/timepad/front-shared.git#f9e7363ba4dc26050fdeb01f2d25315e39c21bcb",
+      "version": "git+https://github.com/timepad/front-shared.git#4e63fee0b9ff0945742c243106db6567f0e1b332",
+      "from": "git+https://github.com/timepad/front-shared.git#4e63fee0b9ff0945742c243106db6567f0e1b332",
       "dev": true
     },
     "fs-extra": {

--- a/src/assets/css/components/cdivider.less
+++ b/src/assets/css/components/cdivider.less
@@ -1,5 +1,3 @@
-@import "../bundle.less";
-
 .cdivider {
   display: block;
   border: 0;

--- a/src/assets/css/otp-styles-bundle.less
+++ b/src/assets/css/otp-styles-bundle.less
@@ -1,0 +1,42 @@
+@import  "./vars.less";
+@import  "./mixins.less";
+
+// Grid system
+@import "./layout/lbrick";
+@import "./layout/lmodules";
+@import "./layout/lpage";
+@import "./layout/lsquare";
+// TODO: NEW
+@import "./layout/lflex";
+@import "./layout/lflexchild";
+@import "./layout/lgap";
+@import "./layout/lgrid";
+@import "./layout/lfloat";
+
+// Typography bundle
+@import "./typo/typo";
+
+// Components
+@import "./components/cdivider";
+@import "./components/cicon";
+@import "../../components/button/cbtn";
+@import "../../components/tabs/ctabs";
+
+// Responsive utils
+@import "./responsive.less";
+
+// TODO: NEW, найти место получше
+body {
+  font-family: @ff;
+  color: @c-black;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-variant-numeric: proportional-nums;
+  overflow-y: auto;
+
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); // TODO: убедиться, что это нормальное решение
+}
+
+:focus:not(.focus-visible) {
+  outline: none;
+}

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -3,7 +3,7 @@ import {Fragment, PropsWithChildren} from 'react';
 import cx from 'classnames';
 import {component} from '../../services/helpers/classHelpers';
 
-import './cbtn.less';
+import './index.less';
 
 export enum ButtonVariant {
     primary = 'primary',

--- a/src/components/button/cbtn.less
+++ b/src/components/button/cbtn.less
@@ -1,5 +1,3 @@
-@import "../../assets/css/bundle.less";
-
 .cbtn-disabled-state (@content) {
   &.cbtn--disabled {
     &, &:active {

--- a/src/components/button/index.less
+++ b/src/components/button/index.less
@@ -1,0 +1,2 @@
+@import "../../assets/css/bundle.less";
+@import "./cbtn.less";

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -7,7 +7,7 @@ import cx from 'classnames';
 import {component} from '../../services/helpers/classHelpers';
 import {action, observable} from 'mobx';
 
-import './ctabs.less';
+import './index.less';
 
 class TabsStore {
     constructor(activeTabId = '') {

--- a/src/components/tabs/ctabs.less
+++ b/src/components/tabs/ctabs.less
@@ -1,5 +1,3 @@
-@import "../../assets/css/bundle.less";
-
 .ctab-bar {
   font-family: @ff;
 

--- a/src/components/tabs/index.less
+++ b/src/components/tabs/index.less
@@ -1,0 +1,2 @@
+@import "../../assets/css/bundle.less";
+@import "./ctabs.less";


### PR DESCRIPTION
1. [ref] Разнесены стили компонентов с импортом основных стилей front-components, для оптимизации собираемого бандла в OTP;
2. [new] Создан отдельный стилевой файл для сборки в OTP.

https://timepad.myjetbrains.com/youtrack/issue/TPI-78