### PR TITLE
Поправлены отступы у дропдауна

### DIFF
--- a/src/components/banner/Banner.tsx
+++ b/src/components/banner/Banner.tsx
@@ -9,14 +9,14 @@ import {Button, ButtonVariant} from '../button';
 
 type CloseClickHandler = () => void;
 
-interface IBannerProps {
+interface IBannerProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
     theme?: string;
     closeable?: boolean;
     icon?: React.ReactElement<React.SVGProps<SVGSVGElement>>;
     onCloseClick?: CloseClickHandler;
 }
 
-export const Banner: FC<IBannerProps> = ({children, closeable = false, onCloseClick, icon}) => {
+export const Banner: FC<IBannerProps> = ({children, closeable = false, onCloseClick, icon, ...props}) => {
     const [show, setShow] = useState(true);
     if (!show) {
         return null;
@@ -32,7 +32,7 @@ export const Banner: FC<IBannerProps> = ({children, closeable = false, onCloseCl
     };
 
     return (
-        <Row className={component('banner')()}>
+        <Row {...props} className={component('banner')()}>
             {icon && <Row.Icon className={component('banner', 'icon')()}>{icon}</Row.Icon>}
             <Row.Body className={component('banner', 'content')()}>{children}</Row.Body>
             {closeable && (

--- a/src/components/dropdown/DropDown.stories.tsx
+++ b/src/components/dropdown/DropDown.stories.tsx
@@ -118,6 +118,18 @@ const DropProfile: React.FC = () => {
                 <List.Item href={'#'} as={'a'}>
                     Избранное
                 </List.Item>
+                <div style={{display: 'flex', flexDirection: 'column'}}>
+                    <Dropdown trigger={() => <List.Item>Выпадающий список</List.Item>} on="hover">
+                        <List variant="dark" size="lg">
+                            <List.Item href={'#'} as={'a'}>
+                                Мои события
+                            </List.Item>
+                            <List.Item href={'#'} as={'a'}>
+                                Мои подписки
+                            </List.Item>
+                        </List>
+                    </Dropdown>
+                </div>
                 <List.Item as={'button'} type={'button'} label="Выход" />
                 <Dropdown.Button label="Стать организатором" />
             </List>

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -182,7 +182,15 @@ export const Dropdown: FC<IDropdownProps> & {
             {...props}
         >
             <div className="dropdown-container" ref={ref}>
-                <div className={cx('dropdown-body', modifier)}>{children}</div>
+                <div
+                    className={cx(
+                        'dropdown-body',
+                        {'dropdown-body--scrollable': window.innerHeight <= Number(rect?.height)},
+                        modifier,
+                    )}
+                >
+                    {children}
+                </div>
             </div>
         </Popup>
     );

--- a/src/components/dropdown/cdropdown.less
+++ b/src/components/dropdown/cdropdown.less
@@ -22,9 +22,12 @@
 
 .dropdown-body {
   box-shadow: @sh-shadow;
-  margin: 15px 0;
   border-radius: 8px;
   overflow: hidden;
+
+  &--scrollable {
+    margin: 15px 0;
+  }
 }
 
 .cdropdown__button {

--- a/src/components/list/Item.tsx
+++ b/src/components/list/Item.tsx
@@ -52,6 +52,7 @@ const Item: React.FC<IItem | any> = React.forwardRef<HTMLElement, IItem>(
 
         const Tag: any = as;
         const mainText = label ? label : children;
+
         return (
             <Tag ref={ref} className={classNames} {...props}>
                 {prefix ? (
@@ -60,7 +61,7 @@ const Item: React.FC<IItem | any> = React.forwardRef<HTMLElement, IItem>(
                             className: cx(
                                 component('icon')(),
                                 component('list-item', 'row-icon')(),
-                                prefix?.props.className,
+                                prefix?.props?.className,
                             ),
                         })}
                     </div>
@@ -81,7 +82,7 @@ const Item: React.FC<IItem | any> = React.forwardRef<HTMLElement, IItem>(
                             className: cx(
                                 component('icon')(),
                                 component('list-item', 'row-icon')(),
-                                suffix?.props.className,
+                                suffix?.props?.className,
                             ),
                         })}
                     </div>

--- a/src/components/list/Item.tsx
+++ b/src/components/list/Item.tsx
@@ -52,7 +52,6 @@ const Item: React.FC<IItem | any> = React.forwardRef<HTMLElement, IItem>(
 
         const Tag: any = as;
         const mainText = label ? label : children;
-
         return (
             <Tag ref={ref} className={classNames} {...props}>
                 {prefix ? (

--- a/src/components/list/Item.tsx
+++ b/src/components/list/Item.tsx
@@ -57,7 +57,11 @@ const Item: React.FC<IItem | any> = React.forwardRef<HTMLElement, IItem>(
                 {prefix ? (
                     <div className={component('list-item', 'prefix')()}>
                         {React.cloneElement(prefix, {
-                            className: cx(component('icon')(), component('list-item', 'row-icon')()),
+                            className: cx(
+                                component('icon')(),
+                                component('list-item', 'row-icon')(),
+                                prefix?.props.className,
+                            ),
                         })}
                     </div>
                 ) : null}
@@ -74,7 +78,11 @@ const Item: React.FC<IItem | any> = React.forwardRef<HTMLElement, IItem>(
                 {suffix ? (
                     <div className={component('list-item', 'suffix')()}>
                         {React.cloneElement(suffix, {
-                            className: cx(component('icon')(), component('list-item', 'row-icon')()),
+                            className: cx(
+                                component('icon')(),
+                                component('list-item', 'row-icon')(),
+                                suffix?.props.className,
+                            ),
                         })}
                     </div>
                 ) : null}

--- a/src/components/list/clist.less
+++ b/src/components/list/clist.less
@@ -60,7 +60,7 @@
 .clist--variant_white .clist-item,
 .clist--variant_transparent .clist-item {
   background-color: transparent;
-  &:hover {
+  &:hover, .popup-hovered-trigger & {
     background-color: @graydark-fade-20;
   }
   &:focus,
@@ -94,7 +94,7 @@
   padding: inherit;
   padding-top: var(--spacing-vertical, 0);
   padding-bottom: var(--spacing-vertical, 0);
-  &:hover {
+  &:hover, .popup-hovered-trigger & {
     background-color: @c-gray-50-fade-20;
   }
   &:focus,

--- a/src/components/popup/index.tsx
+++ b/src/components/popup/index.tsx
@@ -142,6 +142,7 @@ export const Popup = React.forwardRef<IPopupActions, IPopupProps>(
 
         useLayoutEffect(() => {
             if (isOpen) {
+                if (triggerRef.current) triggerRef.current.className = 'popup-hovered-trigger';
                 focusedElBeforeOpen.current = document.activeElement;
                 setPosition();
                 if (contentRef.current) {
@@ -149,6 +150,7 @@ export const Popup = React.forwardRef<IPopupActions, IPopupProps>(
                 }
                 handleLockScroll();
             } else {
+                if (triggerRef.current) triggerRef.current.className = '';
                 resetScroll();
             }
             return () => {


### PR DESCRIPTION
1. [bfx] Исправлена недоработка с лишними отступами сверху и снизу, теперь они добавляются только если дропдаун не вмещается в высоту экрана.
2. [bfx] Исправлен ховер для триггера дочернего дропдауна
3. [bfx] Исправлена передача классов иконке в List.Item и List.Group
4. [bfx] Исправлена передача пропсов в Banner.

https://timepad.myjetbrains.com/youtrack/issue/PL-483