### PR TITLE
Расширение типа пропсов для MaskInput компонента

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/react": "18.0.21",
     "@types/react-dom": "18.0.6",
     "@types/react-modal": "3.13.1",
-    "@types/react-input-mask": "3.0.1",
+    "@types/react-input-mask": "3.0.2",
     "@types/react-transition-group": "4.4.2",
     "@typescript-eslint/eslint-plugin": "4.27.0",
     "@typescript-eslint/parser": "4.27.0",

--- a/src/components/form/TextLight/TextLight.tsx
+++ b/src/components/form/TextLight/TextLight.tsx
@@ -2,9 +2,9 @@ import React, {FC, useMemo} from 'react';
 import {component} from '../../../services/helpers/classHelpers';
 import cx from 'classnames';
 import CheckSvg from '../../../assets/svg/24/icon-check-24.svg';
-import {IFormInputLightProps, IFormTextLightProps} from './TextLight.types';
+import {IFormMaskInputProps, IFormTextLightProps} from './TextLight.types';
 import {Textarea} from '../Textarea';
-import MaskedInput from 'react-input-mask';
+import MaskedInput, {BeforeMaskedStateChangeStates} from 'react-input-mask';
 import './index.less';
 import {FieldMetaProps} from 'formik/dist/types';
 import {ITextareaProps} from '../Textarea/Textarea';
@@ -59,6 +59,23 @@ export const TextLight: FC<React.PropsWithChildren<IFormTextLightProps>> = ({
     );
 };
 
+const maskedChange = ({currentState, nextState}: BeforeMaskedStateChangeStates) => {
+    let {value} = nextState;
+    const {value: currValue = ''} = currentState || {};
+
+    // обрезка placeholder при наборе и автозаполнении
+    if (/^\d{3}/.test(currValue) && currValue.length <= 10) {
+        value = '+7' + currValue;
+    }
+
+    // для номеров, начинающихся с 8
+    if (currValue.startsWith('8') && currValue.length > 10) {
+        value = '+7' + currValue.slice(1);
+    }
+
+    return {...nextState, value};
+};
+
 // TODO: сверху все типизировано, здесь необходимы as, any и спред пропсов, иначе в otp ничего не билдится и куча варнингов
 /* eslint-disable no-unused-vars, @typescript-eslint/no-unused-vars */
 const Input: FC<IFormTextLightProps & Partial<Omit<FieldMetaProps<string>, 'value'>>> = ({
@@ -76,8 +93,23 @@ const Input: FC<IFormTextLightProps & Partial<Omit<FieldMetaProps<string>, 'valu
     if (multiline) {
         return <Textarea value={currentValue} {...(props as ITextareaProps)} />;
     }
-    if (!multiline && (props as IFormInputLightProps).type === 'phone') {
-        return <MaskedInput value={currentValue} mask="+7 (999) 999 99 99" {...(props as IFormInputLightProps)} />;
+    if (!multiline && (props as IFormMaskInputProps).type === 'phone') {
+        const {
+            mask = '+7 (999) 999 99 99',
+            maskChar = null,
+            maskPlaceholder = null,
+            ...restProps
+        } = props as IFormMaskInputProps;
+        return (
+            <MaskedInput
+                value={currentValue}
+                beforeMaskedStateChange={maskedChange}
+                mask={mask}
+                maskChar={maskChar}
+                maskPlaceholder={maskPlaceholder}
+                {...restProps}
+            />
+        );
     }
     return (
         <input value={currentValue} ref={(props as any).inputRef} {...(props as any)} touched={touched?.toString()} />

--- a/src/components/form/TextLight/TextLight.types.ts
+++ b/src/components/form/TextLight/TextLight.types.ts
@@ -1,4 +1,5 @@
 import React, {ReactNode} from 'react';
+import {Props as MaskedInputProps} from 'react-input-mask';
 import {ITextareaProps} from '../Textarea/Textarea';
 
 export type IFormTextLightProps = {
@@ -8,7 +9,7 @@ export type IFormTextLightProps = {
 
     customIcon?: React.ReactElement<React.SVGProps<SVGSVGElement>>;
     onErrorTruncation?: (truncated: boolean) => void;
-} & (IFormInputLightProps | IFormTextareaLightProps);
+} & (IFormInputLightProps | IFormTextareaLightProps | IFormMaskInputProps);
 
 export type IFormInputLightProps = {
     multiline?: false;
@@ -19,3 +20,7 @@ export type IFormTextareaLightProps = {
     multiline: true;
     textareaRef?: React.Ref<HTMLTextAreaElement>;
 } & ITextareaProps;
+
+export type IFormMaskInputProps = {
+    multiline?: false;
+} & MaskedInputProps;


### PR DESCRIPTION

1. [ref][S] Обновлены devDependency для типов MaskInput.
2. [ref][S]  Расширил тип пропсов для MaskInput в TextLight компоненте для большей совмесимости.

https://timepad.myjetbrains.com/youtrack/issue/TPI-601/Zamenit-v-ntp-PhoneInput-na-edinyj-komponent